### PR TITLE
fix: Prevent DiscordRPC crash when text exceeds 128 bytes (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-# Music Discord Rpc  
+# ⚠️ 项目已迁移 / THIS PROJECT HAS MOVED ⚠️
+
+**感谢您的关注和支持！为了更好地进行社区维护（例如开启 Issues 功能），本项目已迁移至一个全新的独立仓库。**  
+**Thank you for your interest! To better maintain the community (e.g., enabling the Issues tab), this project has been moved to a new, independent repository.**
+
+## [➡️ 点击这里前往新仓库 / Click here to go to the new repository](https://github.com/kriYamiHikari/Music-DiscordRPC)
+
+**请在新仓库中提交 Issues、Pull Requests，并请重新 Star ⭐ 新项目以获取最新更新，非常感谢！**  
+**Please submit Issues, Pull Requests, and re-star ⭐ the new project to stay up-to-date. Thank you!**
+
+---
+*(以下为旧的 README 内容...)*
+
+# Music Discord Rpc
   
   
 Enables Discord [Rich Presence](https://discordapp.com/rich-presence) For Netease Cloud Music and Tencent QQ Music.  

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Enables Discord [Rich Presence](https://discordapp.com/rich-presence) For Neteas
   
   
 ### Info
-* This application will auto launch on system start.
-* 这个软件会在你开机的时候自启动.  
+* ~~This application will auto launch on system start.~~
+* ~~这个软件会在你开机的时候自启动.~~
+* 此版本不会开机自启动，若需自启动要手动从托盘图标启动。
   
   
 ### Feature
@@ -17,8 +18,9 @@ Enables Discord [Rich Presence](https://discordapp.com/rich-presence) For Neteas
 * 同步动态到Discord.
 * 支持按钮跟随一起听.  
 * 支持实时状态显示.
+* 支持多个播放器播放信息同时显示
   
   
 ### Screenshot
-<img src="https://github.com/Kxnrl/NetEase-Cloud-Music-DiscordRPC/raw/refs/heads/master/.github/NetEase.png" width="50%" height="50%" /><img src="https://github.com/Kxnrl/NetEase-Cloud-Music-DiscordRPC/raw/refs/heads/master/.github/Tencent.png" width="50%" height="50%" />
+<img width="442" height="337" alt="image" src="https://github.com/user-attachments/assets/9e154853-253a-4f7c-933c-ef3aa963e2d6" />
   

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Enables Discord [Rich Presence](https://discordapp.com/rich-presence) For Neteas
 * 支持按钮跟随一起听.  
 * 支持实时状态显示.
 * 支持多个播放器播放信息同时显示
+* 支持网易云音乐电台/漫游模式
   
   
 ### Screenshot

--- a/Vanessa/Models/PlayerInfo.cs
+++ b/Vanessa/Models/PlayerInfo.cs
@@ -5,16 +5,13 @@ namespace Kxnrl.Vanessa.Models;
 internal readonly record struct PlayerInfo
 {
     public required string Identity { get; init; }
-    public required string Title    { get; init; }
-    public required string Artists  { get; init; }
-    public required string Album    { get; init; }
-    public required string Cover    { get; init; }
+    public required string Title { get; init; }
+    public required string Artists { get; init; }
+    public required string Album { get; init; }
+    public required string Cover { get; init; }
     public required double Schedule { get; init; }
     public required double Duration { get; init; }
-    public required string Url      { get; init; }
+    public required string Url { get; init; }
 
     public required bool Pause { get; init; }
-
-    public override int GetHashCode()
-        => HashCode.Combine(Identity, Pause);
 }

--- a/Vanessa/MusicPlayer.cs
+++ b/Vanessa/MusicPlayer.cs
@@ -4,7 +4,5 @@ namespace Kxnrl.Vanessa;
 
 internal interface IMusicPlayer
 {
-    bool Validate(int pid);
-
     PlayerInfo? GetPlayerInfo();
 }

--- a/Vanessa/Players/Tencent.cs
+++ b/Vanessa/Players/Tencent.cs
@@ -78,6 +78,10 @@ internal sealed class Tencent : IMusicPlayer
         {
             return null;
         }
+        
+        // 停止也视为暂停播放
+        var playStatus = GetPlayStatus();
+        var isPaused = playStatus is 0 or 2;
 
         return new PlayerInfo
         {
@@ -88,9 +92,7 @@ internal sealed class Tencent : IMusicPlayer
             Cover    = GetAlbumThumbnailUrl(),
             Schedule = GetSongSchedule() * 0.001,
             Duration = GetSongDuration() * 0.001,
-            Pause    = IsPaused(),
-
-            // lock
+            Pause    = isPaused,
             Url = $"https://y.qq.com/n/ryqq/songDetail/{id}",
         };
     }
@@ -139,8 +141,12 @@ internal sealed class Tencent : IMusicPlayer
 
         return Encoding.UTF8.GetString(strBuffer);
     }
-
-    // 0 暂停， 1播放， 3缓冲
-    private bool IsPaused()
-        => _process.ReadInt32(_currentSongInfoAddress, (StdStringSize * 4) + 16) == 0;
+    
+    /// <summary>
+    /// 获取播放状态的原始值
+    /// 0: 暂停, 1: 播放, 2: 停止, 3: 缓冲
+    /// </summary>
+    /// <returns>播放状态的整数值</returns>
+    private int GetPlayStatus()
+        => _process.ReadInt32(_currentSongInfoAddress, (StdStringSize * 4) + 16);
 }

--- a/Vanessa/Program.cs
+++ b/Vanessa/Program.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using DiscordRPC;
 using Kxnrl.Vanessa.Players;
+using Kxnrl.Vanessa.Utils;
 using Button = DiscordRPC.Button;
 
 namespace Kxnrl.Vanessa;
@@ -145,8 +146,9 @@ internal class Program
                 {
                     rpcClient.Update(rpc =>
                     {
-                        rpc.Details = $"🎵 {info.Title}";
-                        rpc.State   = $"🎤 {info.Artists}";
+                        // Discord RPC 文本最长支持128个字节，超长部分需截断，否则会引起错误
+                        rpc.Details = StringUtils.GetTruncatedStringByMaxByteLength($"🎵 {info.Title}", 128);
+                        rpc.State   = StringUtils.GetTruncatedStringByMaxByteLength($"🎤 {info.Artists}", 128);
                         rpc.Type    = ActivityType.Listening;
 
                         rpc.Timestamps = new Timestamps(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(info.Schedule)),
@@ -156,7 +158,7 @@ internal class Program
                         rpc.Assets = new Assets
                         {
                             LargeImageKey  = info.Cover,
-                            LargeImageText = $"💿 {info.Album}",
+                            LargeImageText = StringUtils.GetTruncatedStringByMaxByteLength($"💿 {info.Album}", 128),
                             SmallImageKey  = "timg",
                             SmallImageText = "NetEase CloudMusic",
                         };

--- a/Vanessa/Program.cs
+++ b/Vanessa/Program.cs
@@ -72,8 +72,7 @@ internal static class Program
         return new NotifyIcon
         {
             Icon = AppResource.icon,
-            // 既然不是单一支持网易云的，这个部分名字感觉可以修改，先保持原样
-            Text = "NetEase Cloud Music DiscordRPC",
+            Text = "Music Discord RPC",
             ContextMenuStrip = contextMenu
         };
     }

--- a/Vanessa/Program.cs
+++ b/Vanessa/Program.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Diagnostics;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using DiscordRPC;
+using Kxnrl.Vanessa.Models;
 using Kxnrl.Vanessa.Players;
 using Kxnrl.Vanessa.Utils;
 using Button = DiscordRPC.Button;
@@ -32,7 +32,8 @@ internal class Program
 
         if (Constants.GlobalConfig.IsFirstLoad)
         {
-            Win32Api.AutoStart.Set(true);
+            // 启动就设置自动启动感觉不好
+            Win32Api.AutoStart.Set(false);
         }
 
         var netEase = new DiscordRpcClient(NetEaseAppId);
@@ -56,13 +57,13 @@ internal class Program
         notifyMenu.Items.Add(autoButton);
         notifyMenu.Items.Add(exitButton);
 
-        var notifyIcon = new NotifyIcon()
+        var notifyIcon = new NotifyIcon
         {
-            BalloonTipIcon   = ToolTipIcon.Info,
+            BalloonTipIcon = ToolTipIcon.Info,
             ContextMenuStrip = notifyMenu,
-            Text             = "NetEase Cloud Music DiscordRPC",
-            Icon             = AppResource.icon,
-            Visible          = true,
+            Text = "NetEase Cloud Music DiscordRPC",
+            Icon = AppResource.icon,
+            Visible = true,
         };
 
         exitButton.Click += (_, _) =>
@@ -87,110 +88,148 @@ internal class Program
 
     private static async Task UpdateThread(DiscordRpcClient netEase, DiscordRpcClient tencent)
     {
-        IMusicPlayer?     lastInstance  = null;
-        DiscordRpcClient? lastRpcClient = null;
+        PlayerInfo? lastPolledInfo = null;
+        var lastPollTime = DateTime.MinValue;
+        // 定义跳转的容差
+        // 如果实际进度变化与时间流逝的差异超过这个值则认为用户跳转了歌曲进度
+        const double jumpToleranceSeconds = 0.4;
+
+        PlayerInfo? pendingUpdateInfo = null;
+        var lastChangeDetectedTime = DateTime.MinValue;
+        // 防抖时间窗口
+        // 只有在状态稳定超过1.5秒后，才发送更新
+        const double debounceWindowSeconds = 1.5;
 
         while (true)
         {
             try
             {
-                IMusicPlayer     player;
-                DiscordRpcClient rpcClient;
+                IMusicPlayer? player = null;
+                DiscordRpcClient? rpcClient = null;
+                var currentPlayerName = string.Empty;
 
-                if (Win32Api.User32.GetWindowTitle("OrpheusBrowserHost", out _, out var netEaseProcessId))
+                var netEaseHwnd = Win32Api.User32.FindWindow("OrpheusBrowserHost", null);
+                if (netEaseHwnd != IntPtr.Zero &&
+                    Win32Api.User32.GetWindowThreadProcessId(netEaseHwnd, out var netEaseProcessId) != 0 &&
+                    netEaseProcessId != 0)
                 {
-                    player = lastInstance is null
-                        ? new NetEase(netEaseProcessId)
-                        : lastInstance.Validate(netEaseProcessId)
-                            ? lastInstance
-                            : new NetEase(netEaseProcessId);
-
+                    player = new NetEase(netEaseProcessId);
                     rpcClient = netEase;
-                }
-                else if (Win32Api.User32.GetWindowTitle("QQMusic_Daemon_Wnd", out _, out var tencentId))
-                {
-                    player = lastInstance is null
-                        ? new Tencent(tencentId)
-                        : lastInstance.Validate(netEaseProcessId)
-                            ? lastInstance
-                            : new Tencent(tencentId);
-
-                    rpcClient = tencent;
+                    currentPlayerName = "NetEase CloudMusic"; 
                 }
                 else
                 {
-                    lastInstance = null;
-
-                    continue;
-                }
-
-                lastInstance = player;
-
-                var pi = player.GetPlayerInfo();
-
-                Debug.Print(pi is not null ? JsonSerializer.Serialize(pi) : "null");
-
-                if (pi is not { } info)
-                {
-                    lastRpcClient?.ClearPresence();
-                    lastRpcClient = null;
-
-                    continue;
-                }
-
-                if (info.Pause)
-                {
-                    rpcClient.ClearPresence();
-                }
-                else
-                {
-                    rpcClient.Update(rpc =>
+                    var tencentHwnd = Win32Api.User32.FindWindow("QQMusic_Daemon_Wnd", null);
+                    if (tencentHwnd != IntPtr.Zero &&
+                        Win32Api.User32.GetWindowThreadProcessId(tencentHwnd, out var tencentId) != 0 && tencentId != 0)
                     {
-                        // Discord RPC 文本最长支持128个字节，超长部分需截断，否则会引起错误
-                        rpc.Details = StringUtils.GetTruncatedStringByMaxByteLength($"🎵 {info.Title}", 128);
-                        rpc.State   = StringUtils.GetTruncatedStringByMaxByteLength($"🎤 {info.Artists}", 128);
-                        rpc.Type    = ActivityType.Listening;
-
-                        rpc.Timestamps = new Timestamps(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(info.Schedule)),
-                                                        DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(info.Schedule))
-                                                                .Add(TimeSpan.FromSeconds(info.Duration)));
-
-                        rpc.Assets = new Assets
-                        {
-                            LargeImageKey  = info.Cover,
-                            LargeImageText = StringUtils.GetTruncatedStringByMaxByteLength($"💿 {info.Album}", 128),
-                            SmallImageKey  = "timg",
-                            SmallImageText = "NetEase CloudMusic",
-                        };
-
-                        rpc.Buttons =
-                        [
-                            new Button
-                            {
-                                Label = "🎧 Listen",
-                                Url   = info.Url,
-                            },
-                            new Button
-                            {
-                                Label = "👏 View App on GitHub",
-                                Url   = "https://github.com/Kxnrl/NetEase-Cloud-Music-DiscordRPC",
-                            },
-                        ];
-                    });
+                        player = new Tencent(tencentId);
+                        rpcClient = tencent;
+                        currentPlayerName = "Tencent QQMusic";
+                    }
                 }
 
-                lastRpcClient = rpcClient;
+                var currentTime = DateTime.UtcNow;
+                var currentPlayerInfo = player?.GetPlayerInfo();
+                
+                var isStateChanged = false;
+                if ((currentPlayerInfo is null && lastPolledInfo is not null) ||
+                    (currentPlayerInfo is not null && lastPolledInfo is null))
+                {
+                    isStateChanged = true;
+                }
+                else if (currentPlayerInfo is { } currentInfo && lastPolledInfo is { } lastInfo)
+                {
+                    if (currentInfo.Identity != lastInfo.Identity || currentInfo.Pause != lastInfo.Pause)
+                    {
+                        isStateChanged = true;
+                    }
+                    else if (!currentInfo.Pause)
+                    {
+                        var elapsedSeconds = (currentTime - lastPollTime).TotalSeconds;
+                        var progressDelta = currentInfo.Schedule - lastInfo.Schedule;
+                        if (Math.Abs(progressDelta - elapsedSeconds) > jumpToleranceSeconds)
+                        {
+                            isStateChanged = true;
+                        }
+                    }
+                }
+                
+                if (isStateChanged)
+                {
+                    Debug.WriteLine(
+                        $"State change detected. Resetting debounce timer. New song: {currentPlayerInfo?.Title ?? "None"}");
+                    pendingUpdateInfo = currentPlayerInfo;
+                    lastChangeDetectedTime = currentTime;
+                }
+                
+                if (pendingUpdateInfo is not null &&
+                    (currentTime - lastChangeDetectedTime).TotalSeconds > debounceWindowSeconds)
+                {
+                    Debug.WriteLine($"Debounce window passed. Sending RPC update for: {pendingUpdateInfo.Value.Title}");
+                    
+                    var info = pendingUpdateInfo.Value;
+                    if (!info.Pause)
+                    {
+                        rpcClient?.Update(rpc =>
+                        {
+                            rpc.Details = StringUtils.GetTruncatedStringByMaxByteLength($"🎵 {info.Title}", 128);
+                            rpc.State = StringUtils.GetTruncatedStringByMaxByteLength($"🎤 {info.Artists}", 128);
+                            rpc.Type = ActivityType.Listening;
+                            rpc.Timestamps = new Timestamps(
+                                DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(info.Schedule)),
+                                DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(info.Schedule))
+                                    .Add(TimeSpan.FromSeconds(info.Duration))
+                            );
+                            rpc.Assets = new Assets
+                            {
+                                LargeImageKey = info.Cover,
+                                LargeImageText = StringUtils.GetTruncatedStringByMaxByteLength($"💿 {info.Album}", 128),
+                                SmallImageKey = "timg",
+                                SmallImageText = currentPlayerName,
+                            };
+                            rpc.Buttons =
+                            [
+                                new Button { Label = "🎧 Listen", Url = info.Url },
+                                new Button
+                                {
+                                    Label = "👏 View App on GitHub",
+                                    Url = "https://github.com/Kxnrl/NetEase-Cloud-Music-DiscordRPC"
+                                },
+                            ];
+                        });
+                    }
+                    else
+                    {
+                        rpcClient?.ClearPresence();
+                    }
+                    
+                    pendingUpdateInfo = null;
+                }
+                
+                if (currentPlayerInfo is null && pendingUpdateInfo is not null)
+                {
+                    Debug.WriteLine($"Player closed. Clearing pending update.");
+                    rpcClient?.ClearPresence();
+                    pendingUpdateInfo = null;
+                }
+                
+                lastPolledInfo = currentPlayerInfo;
+                lastPollTime = currentTime;
             }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                lastPolledInfo = null;
+                pendingUpdateInfo = null;
             }
             finally
             {
                 // 用户就喜欢超低内存占用
                 // 但是实际上来说并没有什么卵用
-                GC.Collect();
-                GC.WaitForFullGCComplete();
+                // (所以建议直接注释掉，别强制手动gc了，直接做内存优化)
+                // GC.Collect();
+                // GC.WaitForFullGCComplete();
 
                 await Task.Delay(TimeSpan.FromMilliseconds(233));
             }

--- a/Vanessa/Program.cs
+++ b/Vanessa/Program.cs
@@ -1,238 +1,80 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using DiscordRPC;
-using Kxnrl.Vanessa.Models;
-using Kxnrl.Vanessa.Players;
-using Kxnrl.Vanessa.Utils;
-using Button = DiscordRPC.Button;
 
 namespace Kxnrl.Vanessa;
 
-internal class Program
+internal static class Program
 {
     private const string NetEaseAppId = "481562643958595594";
     private const string TencentAppId = "903485504899665990";
 
-    private static async Task Main()
+    [STAThread]
+    private static void Main()
     {
-        // check run once
-        _ = new Mutex(true, "MusicDiscordRpc", out var allow);
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
 
-        if (!allow)
+        // 单实例运行
+        using var mutex = new Mutex(true, "MusicDiscordRpc", out var isNewInstance);
+        if (!isNewInstance)
         {
             MessageBox.Show("MusicDiscordRpc is already running.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-
-            Environment.Exit(-1);
-
             return;
         }
 
-        if (Constants.GlobalConfig.IsFirstLoad)
+        // 初始化RPC客户端
+        var netEaseClient = new DiscordRpcClient(NetEaseAppId);
+        var tencentClient = new DiscordRpcClient(TencentAppId);
+        netEaseClient.Initialize();
+        tencentClient.Initialize();
+
+        if (!netEaseClient.IsInitialized || !tencentClient.IsInitialized)
         {
-            // 启动就设置自动启动感觉不好
-            Win32Api.AutoStart.Set(false);
+            MessageBox.Show("Failed to initialize Discord RPC client.", "Error", MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
         }
 
-        var netEase = new DiscordRpcClient(NetEaseAppId);
-        var tencent = new DiscordRpcClient(TencentAppId);
-        netEase.Initialize();
-        tencent.Initialize();
+        // 核心服务
+        var rpcManager = new RpcManager(netEaseClient, tencentClient);
+        Task.Run(rpcManager.Start);
 
-        if (!netEase.IsInitialized || !tencent.IsInitialized)
-        {
-            MessageBox.Show("Failed to init rpc client.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            Environment.Exit(-1);
-        }
-
-        // TODO Online Signatures
-        await Task.CompletedTask;
-
-        var notifyMenu = new ContextMenuStrip();
-
-        var exitButton = new ToolStripMenuItem("Exit");
-        var autoButton = new ToolStripMenuItem("AutoStart" + "    " + (Win32Api.AutoStart.Check() ? "√" : "✘"));
-        notifyMenu.Items.Add(autoButton);
-        notifyMenu.Items.Add(exitButton);
-
-        var notifyIcon = new NotifyIcon
-        {
-            BalloonTipIcon = ToolTipIcon.Info,
-            ContextMenuStrip = notifyMenu,
-            Text = "NetEase Cloud Music DiscordRPC",
-            Icon = AppResource.icon,
-            Visible = true,
-        };
-
-        exitButton.Click += (_, _) =>
-        {
-            notifyIcon.Visible = false;
-            Thread.Sleep(100);
-            Environment.Exit(0);
-        };
-
-        autoButton.Click += (_, _) =>
-        {
-            var x = Win32Api.AutoStart.Check();
-
-            Win32Api.AutoStart.Set(!x);
-
-            autoButton.Text = "AutoStart" + "    " + (Win32Api.AutoStart.Check() ? "√" : "✘");
-        };
-
-        _ = Task.Run(async () => await UpdateThread(netEase, tencent));
+        // 托盘图标
+        using var trayIcon = CreateTrayIcon();
+        trayIcon.Visible = true;
         Application.Run();
+
+        // 应用退出时清理RPC客户端
+        netEaseClient.Dispose();
+        tencentClient.Dispose();
     }
 
-    private static async Task UpdateThread(DiscordRpcClient netEase, DiscordRpcClient tencent)
+    /// <summary>
+    /// 创建并配置系统托盘图标及其菜单
+    /// </summary>
+    private static NotifyIcon CreateTrayIcon()
     {
-        PlayerInfo? lastPolledInfo = null;
-        var lastPollTime = DateTime.MinValue;
-        // 定义跳转的容差
-        // 如果实际进度变化与时间流逝的差异超过这个值则认为用户跳转了歌曲进度
-        const double jumpToleranceSeconds = 0.4;
+        var autoStartMenuItem = new ToolStripMenuItem("AutoStart") { CheckOnClick = true };
+        var exitMenuItem = new ToolStripMenuItem("Exit");
 
-        PlayerInfo? pendingUpdateInfo = null;
-        var lastChangeDetectedTime = DateTime.MinValue;
-        // 防抖时间窗口
-        // 只有在状态稳定超过1.5秒后，才发送更新
-        const double debounceWindowSeconds = 1.5;
+        var contextMenu = new ContextMenuStrip();
+        contextMenu.Items.Add(autoStartMenuItem);
+        contextMenu.Items.Add(new ToolStripSeparator());
+        contextMenu.Items.Add(exitMenuItem);
 
-        while (true)
+        autoStartMenuItem.Checked = Win32Api.AutoStart.Check();
+        autoStartMenuItem.Click += (_, _) => Win32Api.AutoStart.Set(autoStartMenuItem.Checked);
+        exitMenuItem.Click += (_, _) => Application.Exit();
+
+        return new NotifyIcon
         {
-            try
-            {
-                IMusicPlayer? player = null;
-                DiscordRpcClient? rpcClient = null;
-                var currentPlayerName = string.Empty;
-
-                var netEaseHwnd = Win32Api.User32.FindWindow("OrpheusBrowserHost", null);
-                if (netEaseHwnd != IntPtr.Zero &&
-                    Win32Api.User32.GetWindowThreadProcessId(netEaseHwnd, out var netEaseProcessId) != 0 &&
-                    netEaseProcessId != 0)
-                {
-                    player = new NetEase(netEaseProcessId);
-                    rpcClient = netEase;
-                    currentPlayerName = "NetEase CloudMusic"; 
-                }
-                else
-                {
-                    var tencentHwnd = Win32Api.User32.FindWindow("QQMusic_Daemon_Wnd", null);
-                    if (tencentHwnd != IntPtr.Zero &&
-                        Win32Api.User32.GetWindowThreadProcessId(tencentHwnd, out var tencentId) != 0 && tencentId != 0)
-                    {
-                        player = new Tencent(tencentId);
-                        rpcClient = tencent;
-                        currentPlayerName = "Tencent QQMusic";
-                    }
-                }
-
-                var currentTime = DateTime.UtcNow;
-                var currentPlayerInfo = player?.GetPlayerInfo();
-                
-                var isStateChanged = false;
-                if ((currentPlayerInfo is null && lastPolledInfo is not null) ||
-                    (currentPlayerInfo is not null && lastPolledInfo is null))
-                {
-                    isStateChanged = true;
-                }
-                else if (currentPlayerInfo is { } currentInfo && lastPolledInfo is { } lastInfo)
-                {
-                    if (currentInfo.Identity != lastInfo.Identity || currentInfo.Pause != lastInfo.Pause)
-                    {
-                        isStateChanged = true;
-                    }
-                    else if (!currentInfo.Pause)
-                    {
-                        var elapsedSeconds = (currentTime - lastPollTime).TotalSeconds;
-                        var progressDelta = currentInfo.Schedule - lastInfo.Schedule;
-                        if (Math.Abs(progressDelta - elapsedSeconds) > jumpToleranceSeconds)
-                        {
-                            isStateChanged = true;
-                        }
-                    }
-                }
-                
-                if (isStateChanged)
-                {
-                    Debug.WriteLine(
-                        $"State change detected. Resetting debounce timer. New song: {currentPlayerInfo?.Title ?? "None"}");
-                    pendingUpdateInfo = currentPlayerInfo;
-                    lastChangeDetectedTime = currentTime;
-                }
-                
-                if (pendingUpdateInfo is not null &&
-                    (currentTime - lastChangeDetectedTime).TotalSeconds > debounceWindowSeconds)
-                {
-                    Debug.WriteLine($"Debounce window passed. Sending RPC update for: {pendingUpdateInfo.Value.Title}");
-                    
-                    var info = pendingUpdateInfo.Value;
-                    if (!info.Pause)
-                    {
-                        rpcClient?.Update(rpc =>
-                        {
-                            rpc.Details = StringUtils.GetTruncatedStringByMaxByteLength($"🎵 {info.Title}", 128);
-                            rpc.State = StringUtils.GetTruncatedStringByMaxByteLength($"🎤 {info.Artists}", 128);
-                            rpc.Type = ActivityType.Listening;
-                            rpc.Timestamps = new Timestamps(
-                                DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(info.Schedule)),
-                                DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(info.Schedule))
-                                    .Add(TimeSpan.FromSeconds(info.Duration))
-                            );
-                            rpc.Assets = new Assets
-                            {
-                                LargeImageKey = info.Cover,
-                                LargeImageText = StringUtils.GetTruncatedStringByMaxByteLength($"💿 {info.Album}", 128),
-                                SmallImageKey = "timg",
-                                SmallImageText = currentPlayerName,
-                            };
-                            rpc.Buttons =
-                            [
-                                new Button { Label = "🎧 Listen", Url = info.Url },
-                                new Button
-                                {
-                                    Label = "👏 View App on GitHub",
-                                    Url = "https://github.com/Kxnrl/NetEase-Cloud-Music-DiscordRPC"
-                                },
-                            ];
-                        });
-                    }
-                    else
-                    {
-                        rpcClient?.ClearPresence();
-                    }
-                    
-                    pendingUpdateInfo = null;
-                }
-                
-                if (currentPlayerInfo is null && pendingUpdateInfo is not null)
-                {
-                    Debug.WriteLine($"Player closed. Clearing pending update.");
-                    rpcClient?.ClearPresence();
-                    pendingUpdateInfo = null;
-                }
-                
-                lastPolledInfo = currentPlayerInfo;
-                lastPollTime = currentTime;
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                lastPolledInfo = null;
-                pendingUpdateInfo = null;
-            }
-            finally
-            {
-                // 用户就喜欢超低内存占用
-                // 但是实际上来说并没有什么卵用
-                // (所以建议直接注释掉，别强制手动gc了，直接做内存优化)
-                // GC.Collect();
-                // GC.WaitForFullGCComplete();
-
-                await Task.Delay(TimeSpan.FromMilliseconds(233));
-            }
-        }
+            Icon = AppResource.icon,
+            // 既然不是单一支持网易云的，这个部分名字感觉可以修改，先保持原样
+            Text = "NetEase Cloud Music DiscordRPC",
+            ContextMenuStrip = contextMenu
+        };
     }
 }

--- a/Vanessa/Utils/ProcessUtils.cs
+++ b/Vanessa/Utils/ProcessUtils.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Kxnrl.Vanessa.Utils;
+
+internal static class ProcessUtils
+{
+    private static readonly Dictionary<(int, string), nint> ModuleAddressCache = new();
+    private static int _lastPid = -1;
+    
+    /// <summary>
+    /// 获取指定进程中模块的基地址，利用缓存避免重复的慢速查询。
+    /// </summary>
+    public static nint GetModuleBaseAddress(int pid, string moduleName)
+    {
+        if (pid != _lastPid)
+        {
+            ModuleAddressCache.Clear();
+            _lastPid = pid;
+        }
+
+        var cacheKey = (pid, moduleName);
+        if (ModuleAddressCache.TryGetValue(cacheKey, out var cachedAddress))
+        {
+            return cachedAddress;
+        }
+        
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            foreach (ProcessModule module in process.Modules)
+            {
+                if (!module.ModuleName.Equals(moduleName, StringComparison.OrdinalIgnoreCase)) continue;
+                var baseAddress = module.BaseAddress;
+                ModuleAddressCache[cacheKey] = baseAddress;
+                return baseAddress;
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[ERROR] Failed to get modules for PID {pid}: {ex.Message}");
+        }
+        
+        ModuleAddressCache[cacheKey] = IntPtr.Zero;
+        return IntPtr.Zero;
+    }
+}

--- a/Vanessa/Utils/StringUtils.cs
+++ b/Vanessa/Utils/StringUtils.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Text;
+
+namespace Kxnrl.Vanessa.Utils;
+
+public class StringUtils
+{
+    /// <summary>
+    /// 在一串 UTF-8 字节串中从后往前找到最后一个完整的 Unicode 字符
+    /// </summary>
+    /// <param name="buffer">要查找的字节串</param>
+    /// <param name="byteCount">要查找的字节串的长度</param>
+    /// <returns>最后一个完整 Unicode 字符的下标</returns>
+    public static int FindLastCompleteCharIndex(byte[] buffer, int byteCount)
+    {
+        // 从字节数组的末尾向前遍历，找到最后一个完整的字符的索引
+        for (var position = byteCount - 1; position >= 0; position--)
+        {
+            // 如果当前字节是单字节字符（ASCII字符），直接返回当前位置
+            if (buffer[position] < 0x80)
+                return position;
+
+            // 如果当前字节是多字节字符的延续字节（即高两位为10），继续向前查找
+            if ((buffer[position] & 0xC0) != 0x80) continue;
+
+            // 计算当前字符的字节数
+            var count = 0;
+            while (position >= 0 && (buffer[position] & 0xC0) == 0x80)
+            {
+                position--;
+                count++;
+            }
+
+            // 如果已经遍历到数组的开头，继续处理下一个字符
+            if (position < 0) continue;
+
+            // 获取当前字符的起始字节
+            var lead = buffer[position];
+            int required;
+
+            // 根据起始字节的值判断当前字符的字节数
+            switch (lead >> 4)
+            {
+                case 0b1100: required = 1; break; // 2字节字符
+                case 0b1110: required = 2; break; // 3字节字符
+                case 0b1111: required = 3; break; // 4字节字符
+                default: continue; // 无效字符，继续处理下一个字符
+            }
+
+            // 如果当前字符的字节数与预期一致，返回当前字符的起始位置
+            if (count == required)
+                return position;
+        }
+
+        // 如果没有找到完整的字符，返回-1
+        return -1;
+    }
+
+    /// <summary>
+    /// 将一串字符串截断到最大长度,并在最后添加省略号
+    /// </summary>
+    /// <param name="str">要截断的字符串</param>
+    /// <param name="maxLength">最大长度</param>
+    public static string GetTruncatedStringByMaxByteLength(string str, int maxLength)
+    {
+        // 如果字符串长度小于最大长度，直接返回
+        var strBuffer = Encoding.UTF8.GetBytes(str);
+        if (strBuffer.Length < maxLength) return str;
+
+        // 预留3个字节给省略号
+        var truncatedLength = maxLength - 3;
+        var truncatedBuffer = new byte[truncatedLength];
+        Buffer.BlockCopy(strBuffer, 0, truncatedBuffer, 0, truncatedLength);
+        
+        // 找到最后一个完整的字符的索引
+        var lastCompleteCharIndex = FindLastCompleteCharIndex(truncatedBuffer, truncatedLength);
+        if (lastCompleteCharIndex == -1) return "Error";
+        
+        // 创建截断后的字节数组
+        var truncatedString = new byte[lastCompleteCharIndex];
+        Buffer.BlockCopy(truncatedBuffer, 0, truncatedString, 0, lastCompleteCharIndex);
+        
+        // 将省略号转换为字节数组
+        var ellipsisByteString = "..."u8.ToArray();
+        
+        // 创建最终的字节数组，包含截断后的字符串和省略号
+        var finalBuffer = new byte[truncatedString.Length + ellipsisByteString.Length];
+        Buffer.BlockCopy(truncatedString, 0, finalBuffer, 0, truncatedString.Length);
+        Buffer.BlockCopy(ellipsisByteString, 0, finalBuffer, truncatedString.Length, ellipsisByteString.Length);
+        
+        // 将最终的字节数组转换为字符串
+        return Encoding.UTF8.GetString(finalBuffer);
+    }
+}

--- a/Vanessa/Utils/StringUtils.cs
+++ b/Vanessa/Utils/StringUtils.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Kxnrl.Vanessa.Utils;
 
-public class StringUtils
+public static class StringUtils
 {
     /// <summary>
     /// 在一串 UTF-8 字节串中从后往前找到最后一个完整的 Unicode 字符
@@ -11,7 +11,7 @@ public class StringUtils
     /// <param name="buffer">要查找的字节串</param>
     /// <param name="byteCount">要查找的字节串的长度</param>
     /// <returns>最后一个完整 Unicode 字符的下标</returns>
-    public static int FindLastCompleteCharIndex(byte[] buffer, int byteCount)
+    private static int FindLastCompleteCharIndex(byte[] buffer, int byteCount)
     {
         // 从字节数组的末尾向前遍历，找到最后一个完整的字符的索引
         for (var position = byteCount - 1; position >= 0; position--)

--- a/Vanessa/Vanessa.csproj
+++ b/Vanessa/Vanessa.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>Kxnrl.Vanessa</RootNamespace>
     <VersionPrefix>1.0</VersionPrefix>
     <VersionSuffix>1</VersionSuffix>
-    <Version>3.0</Version>
+    <Version>3.0.1</Version>
     <PackageProjectUrl>https://github.com/Kxnrl/NetEase-Cloud-Music-DiscordRPC</PackageProjectUrl>
     <Copyright>©2024 Kyle</Copyright>
     <RepositoryUrl>https://github.com/Kxnrl/NetEase-Cloud-Music-DiscordRPC</RepositoryUrl>

--- a/Vanessa/Win32Api/Memory.cs
+++ b/Vanessa/Win32Api/Memory.cs
@@ -6,126 +6,127 @@ namespace Kxnrl.Vanessa.Win32Api;
 
 internal static class Memory
 {
-    public static bool FindPattern(string pattern, int processId, nint address, out nint pointer)
+    private static readonly Dictionary<(int, nint), (nint pStart, byte[] memory)> ModuleCache = new();
+    private static int _lastProcessId = -1;
+
+    public static bool FindPattern(string pattern, int processId, nint moduleBaseAddress, out nint pointer)
     {
-        var memory = new ProcessMemory(processId);
-
-        var ntOffset = memory.ReadInt32(address, 0x3C);
-        var ntHeader = address + ntOffset;
-
-        // IMAGE
-        var fileHeader  = ntHeader + 4;
-        var sections    = memory.ReadInt16(ntHeader,   6);
-        var sectionSize = memory.ReadInt16(fileHeader, 16);
-
-        // OPT HEADER
-        var optHeader     = fileHeader + 20;
-        var sectionHeader = optHeader  + sectionSize;
-
-        var cursor = sectionHeader;
-
-        var pStart      = nint.Zero;
-        var memoryBlock = new List<byte>();
-
-        for (var i = 0; i < sections; i++)
+        if (processId != _lastProcessId)
         {
-            var name = memory.ReadInt64(cursor);
-
-            if (name == 0x747865742E)
-            {
-                var offset = memory.ReadInt32(cursor, 12);
-
-                pStart = address + offset;
-
-                var size   = memory.ReadInt32(cursor, 8);
-                var buffer = memory.ReadBytes(pStart, size);
-                memoryBlock.AddRange(buffer);
-
-                break;
-            }
-
-            cursor += 40;
+            ModuleCache.Clear();
+            _lastProcessId = processId;
         }
 
-        pointer = FindPattern(pattern, pStart, memoryBlock);
+        (nint pStart, byte[] memoryBlock) cacheEntry;
+
+        if (!ModuleCache.TryGetValue((processId, moduleBaseAddress), out cacheEntry))
+        {
+            var memory = new ProcessMemory(processId);
+
+            try
+            {
+                var ntOffset = memory.ReadInt32(moduleBaseAddress, 0x3C);
+                var ntHeader = moduleBaseAddress + ntOffset;
+
+                var fileHeader = ntHeader + 4;
+                var optHeader = fileHeader + 20;
+
+                var sectionSize = memory.ReadInt16(fileHeader, 16);
+                var sections = memory.ReadInt16(ntHeader, 6);
+                var sectionHeader = optHeader + sectionSize;
+
+                var cursor = sectionHeader;
+
+                for (var i = 0; i < sections; i++)
+                {
+                    if (memory.ReadInt64(cursor) == 0x747865742E)
+                    {
+                        var pOffset = memory.ReadInt32(cursor, 12);
+                        var pSize = memory.ReadInt32(cursor, 8);
+
+                        cacheEntry.pStart = moduleBaseAddress + pOffset;
+                        cacheEntry.memoryBlock = memory.ReadBytes(cacheEntry.pStart, pSize);
+
+                        ModuleCache[(processId, moduleBaseAddress)] = cacheEntry;
+                        break;
+                    }
+
+                    cursor += 40; // Size of IMAGE_SECTION_HEADER
+                }
+            }
+            catch (Exception)
+            {
+                pointer = nint.Zero;
+                return false;
+            }
+        }
+
+        if (cacheEntry.memoryBlock is null)
+        {
+            pointer = nint.Zero;
+            return false;
+        }
+
+        pointer = FindPattern(pattern, cacheEntry.pStart, cacheEntry.memoryBlock);
 
         return pointer != nint.Zero;
     }
 
-    private static nint FindPattern(string pattern, nint pStart, List<byte> memoryBlock)
+    private static nint FindPattern(string pattern, nint pStart, byte[] memoryBlock)
     {
-        if (pattern.Length == 0 || pStart == nint.Zero || memoryBlock.Count == 0)
+        if (string.IsNullOrEmpty(pattern) || pStart == nint.Zero || memoryBlock.Length == 0)
         {
             return nint.Zero;
         }
 
-        var bytes  = ParseSignature(pattern);
-        var first  = bytes[0];
-        var result = nint.Zero;
+        var patternBytes = ParseSignature(pattern);
+        var firstByte = patternBytes[0];
+        var searchRange = memoryBlock.Length - patternBytes.Length;
 
-        var range = memoryBlock.Count - bytes.Length;
-
-        for (var i = 0; i < range; i++)
+        for (var i = 0; i < searchRange; i++)
         {
-            if (first != 0xFFFF)
+            if (firstByte != 0xFFFF)
             {
-                i = memoryBlock.IndexOf((byte) first, i);
-
+                i = Array.IndexOf(memoryBlock, (byte)firstByte, i);
                 if (i == -1)
                 {
                     break;
                 }
             }
-
+            
             var found = true;
-
-            for (var j = 1; j < bytes.Length; j++)
+            for (var j = 1; j < patternBytes.Length; j++)
             {
-                var wildcard = bytes[j] == 0xFFFF;
-                var equals   = bytes[j] == memoryBlock[i + j];
-
-                if (wildcard || equals)
-                {
-                    continue;
-                }
-
+                if (patternBytes[j] == 0xFFFF || patternBytes[j] == memoryBlock[i + j]) continue;
                 found = false;
-
                 break;
             }
 
-            if (!found)
+            if (found)
             {
-                continue;
+                return nint.Add(pStart, i);
             }
-
-            result = nint.Add(pStart, i);
-
-            break;
         }
 
-        return result;
+        return nint.Zero;
     }
 
     private static ushort[] ParseSignature(string signature)
     {
-        var bytesStr = signature.Split(' ')
-                                .AsSpan();
-
+        var bytesStr = signature.Split(' ');
         var bytes = new ushort[bytesStr.Length];
 
         for (var i = 0; i < bytes.Length; i++)
         {
             var str = bytesStr[i];
-
             if (str.Contains('?'))
             {
                 bytes[i] = 0xFFFF;
-
-                continue;
             }
-
-            bytes[i] = Convert.ToByte(str, 16);
+            else
+            {
+                bytes[i] = Convert.ToByte(str, 16);
+            }
         }
 
         return bytes;
@@ -172,7 +173,8 @@ internal sealed class ProcessMemory
         => BitConverter.ToUInt32(ReadBytes(IntPtr.Add(address, offset), 4), 0);
 
     [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool ReadProcessMemory(IntPtr pHandle, IntPtr address, byte[] buffer, int size, IntPtr bytesRead);
+    private static extern bool ReadProcessMemory(IntPtr pHandle, IntPtr address, byte[] buffer, int size,
+        IntPtr bytesRead);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern IntPtr OpenProcess(int dwDesiredAccess, IntPtr bInheritHandle, int dwProcessId);

--- a/Vanessa/Win32Api/Memory.cs
+++ b/Vanessa/Win32Api/Memory.cs
@@ -17,9 +17,7 @@ internal static class Memory
             _lastProcessId = processId;
         }
 
-        (nint pStart, byte[] memoryBlock) cacheEntry;
-
-        if (!ModuleCache.TryGetValue((processId, moduleBaseAddress), out cacheEntry))
+        if (!ModuleCache.TryGetValue((processId, moduleBaseAddress), out (nint pStart, byte[] memoryBlock) cacheEntry))
         {
             var memory = new ProcessMemory(processId);
 
@@ -133,20 +131,16 @@ internal static class Memory
     }
 }
 
-internal sealed class ProcessMemory
+internal sealed class ProcessMemory(nint process)
 {
-    private readonly nint _process;
-
-    public ProcessMemory(nint process)
-        => _process = process;
-
-    public ProcessMemory(int processId)
-        => _process = OpenProcess(0x0010, IntPtr.Zero, processId);
+    public ProcessMemory(int processId) : this(OpenProcess(0x0010, IntPtr.Zero, processId))
+    {
+    }
 
     public byte[] ReadBytes(IntPtr offset, int length)
     {
         var bytes = new byte[length];
-        ReadProcessMemory(_process, offset, bytes, length, IntPtr.Zero);
+        ReadProcessMemory(process, offset, bytes, length, IntPtr.Zero);
 
         return bytes;
     }

--- a/Vanessa/Win32Api/User32.cs
+++ b/Vanessa/Win32Api/User32.cs
@@ -27,8 +27,8 @@ internal static class User32
     [DllImport("user32.dll", SetLastError = true)]
     private static extern int GetWindowRect(IntPtr hwnd, out RECT rc);
 
-    [DllImport("user32.dll", EntryPoint = "FindWindow")]
-    private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+    [DllImport("user32.dll", EntryPoint = "FindWindow",SetLastError = true)]
+    internal static extern IntPtr FindWindow(string? lpClassName, string? lpWindowName);
 
     private delegate bool EnumWindowsProc(IntPtr hWnd, int lParam);
 
@@ -45,7 +45,7 @@ internal static class User32
     private static extern int GetWindowTextLength(IntPtr hWnd);
 
     [DllImport("user32.dll")]
-    private static extern int GetWindowThreadProcessId(IntPtr handle, out int pid);
+    internal static extern int GetWindowThreadProcessId(IntPtr handle, out int pid);
 
     private static string GetClassName(IntPtr hwnd)
     {


### PR DESCRIPTION
- Added string truncation to handle text overflow and prevent crashes.
- Fixed a bug where text longer than 128 bytes would cause the program to crash or behave unexpectedly.
- Ensured that all text sent to DiscordRPC is truncated to the 128-byte limit.